### PR TITLE
Change: Change validation to occur onTextChange instead of onFocusChange

### DIFF
--- a/projects/noloan/app/src/main/java/hasadna/noloan/lawsuit/fragments/LawsuitFormFragment.java
+++ b/projects/noloan/app/src/main/java/hasadna/noloan/lawsuit/fragments/LawsuitFormFragment.java
@@ -1,24 +1,20 @@
 package hasadna.noloan.lawsuit.fragments;
 
 import android.animation.ObjectAnimator;
-import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
 import android.app.DatePickerDialog;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.design.widget.TextInputEditText;
 import android.support.v4.app.Fragment;
-import android.view.Gravity;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
-import android.widget.LinearLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.util.Calendar;
 
@@ -58,9 +54,18 @@ public class LawsuitFormFragment extends Fragment {
     scrollView = rootView.findViewById(R.id.ScrollView_formFragment);
 
     // Validate user id number
-    userId.setOnFocusChangeListener(
-        (v, hasFocus) -> {
-          validateIdNumber(userId.getText().toString());
+    userId.addTextChangedListener(
+        new TextWatcher() {
+          @Override
+          public void afterTextChanged(Editable s) {
+            validateIdNumber(userId.getText().toString());
+          }
+
+          @Override
+          public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+          @Override
+          public void onTextChanged(CharSequence s, int start, int before, int count) {}
         });
 
     // Display court's detail in TextViews

--- a/projects/noloan/app/src/main/res/drawable/ic_announcment.xml
+++ b/projects/noloan/app/src/main/res/drawable/ic_announcment.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM13,11h-2L11,5h2v6zM13,15h-2v-2h2v2z"/>
+</vector>


### PR DESCRIPTION
Prevents the scenario where the user stays on focus in the ID field, and clicks to the next fragment from there, in this case validation won't take place and the user will proceed to the next fragment (No focus change...).